### PR TITLE
Fix cache target generation

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7630,7 +7630,7 @@ function getAllStages() {
     return [
         ...getBaseStages(),
         core.getInput('testenv-stage').trim(),
-        core.getInput('testenv-stage').trim(),
+        core.getInput('server-stage').trim(),
     ];
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -7627,11 +7627,15 @@ function getBaseStages() {
     return core.getInput('stages').split(',').map(stage => stage.trim());
 }
 function getAllStages() {
-    return [
+    const stages = [
         ...getBaseStages(),
-        core.getInput('testenv-stage').trim(),
         core.getInput('server-stage').trim(),
     ];
+    const testStage = core.getInput('testenv-stage').trim();
+    if (testStage !== '') {
+        stages.push(testStage);
+    }
+    return stages;
 }
 
 ;// CONCATENATED MODULE: ./src/index.ts

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -43,6 +43,6 @@ export function getAllStages(): string[] {
   return [
     ...getBaseStages(),
     core.getInput('testenv-stage').trim(),
-    core.getInput('testenv-stage').trim(),
+    core.getInput('server-stage').trim(),
   ]
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -40,9 +40,14 @@ export function getBaseStages(): string[] {
 }
 
 export function getAllStages(): string[] {
-  return [
+  const stages = [
     ...getBaseStages(),
-    core.getInput('testenv-stage').trim(),
     core.getInput('server-stage').trim(),
   ]
+
+  const testStage = core.getInput('testenv-stage').trim()
+  if (testStage !== '') {
+    stages.push(testStage)
+  }
+  return stages
 }


### PR DESCRIPTION
The layer list generation erroneously a) included the testenv stage twice (instead of test+server), and b) failed to remove the test stage when it isn't set. This corrects both issues.