### PR TITLE
Refactor internals

### DIFF
--- a/.github/workflows/self-test-multistage-docker-build.yml
+++ b/.github/workflows/self-test-multistage-docker-build.yml
@@ -79,7 +79,7 @@ jobs:
           repository: ghcr.io/firehed/actions
           stages: env, configured
           server-stage: server
-          quiet: false
+          # quiet: false
 
       - name: Print outputs
         run: |

--- a/.github/workflows/self-test-multistage-docker-build.yml
+++ b/.github/workflows/self-test-multistage-docker-build.yml
@@ -79,9 +79,9 @@ jobs:
           repository: ghcr.io/firehed/actions
           stages: env, configured
           server-stage: server
-          # quiet: false
 
       - name: Print outputs
         run: |
           echo "Server: ${{ steps.build.outputs.server-tag }}"
           echo "Testenv: ${{ steps.build.outputs.testenv-tag }}"
+          echo "Commit: ${{ steps.build.outputs.commit }}"

--- a/.github/workflows/self-test-multistage-docker-build.yml
+++ b/.github/workflows/self-test-multistage-docker-build.yml
@@ -42,6 +42,7 @@ jobs:
           stages: env, configured
           testenv-stage: testenv
           server-stage: server
+          quiet: false
 
   test:
     name: 'test'
@@ -78,6 +79,7 @@ jobs:
           repository: ghcr.io/firehed/actions
           stages: env, configured
           server-stage: server
+          quiet: false
 
       - name: Print outputs
         run: |

--- a/dist/index.js
+++ b/dist/index.js
@@ -7650,7 +7650,7 @@ function getTaggedImageForStage(stage, tag) {
     return `${image}:${tag}`;
 }
 async function runDockerCommand(command, ...args) {
-    const quiet = core.getInput('quiet') ? '--quiet' : '';
+    const quiet = core.getBooleanInput('quiet') ? '--quiet' : '';
     const exitCode = await (0,exec.exec)('docker', [command, quiet, ...args]);
     return {
         exitCode,

--- a/dist/index.js
+++ b/dist/index.js
@@ -7747,7 +7747,7 @@ async function build() {
  * a tag specific to the ref/branch that the action is run on.
  */
 async function buildStage(stage) {
-    core.info(`Building stage: ${stage}`);
+    core.startGroup(`Building stage: ${stage}`);
     const dockerfile = core.getInput('dockerfile');
     const targetTag = getTaggedImageForStage(stage, getTagForRun());
     const cacheFromArg = Array.from(getAllPossibleCacheTargets())
@@ -7759,6 +7759,7 @@ async function buildStage(stage) {
         throw 'Docker build failed';
     }
     dockerPush(targetTag);
+    core.endGroup();
     return targetTag;
 }
 async function dockerPush(taggedImage) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -7678,12 +7678,12 @@ async function run() {
 async function pull() {
     const tagsToTry = [getTagForRun(), 'latest'];
     const stages = getAllStages();
-    stages.forEach((stage) => {
+    stages.forEach(async (stage) => {
         for (const tag of tagsToTry) {
             const taggedName = getTaggedImageForStage(stage, tag);
             try {
                 // FIXME: remove try/catch & examine exit code
-                runDockerCommand('pull', taggedName);
+                await runDockerCommand('pull', taggedName);
                 return;
             }
             catch (error) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -7667,8 +7667,8 @@ async function runDockerCommand(command, ...args) {
 
 async function run() {
     try {
-        await pull();
-        await build();
+        await core.group('Pull images for layer cache', pull);
+        await core.group('Build', build);
     }
     catch (error) {
         core.setFailed(error.message);
@@ -7733,7 +7733,7 @@ async function build() {
  * a tag specific to the ref/branch that the action is run on.
  */
 async function buildStage(stage) {
-    core.info(`Building stage ${stage}`);
+    core.info(`Building stage: ${stage}`);
     const dockerfile = core.getInput('dockerfile');
     const targetTag = getTaggedImageForStage(stage, getTagForRun());
     const cacheFromArg = Array.from(getAllPossibleCacheTargets())

--- a/dist/index.js
+++ b/dist/index.js
@@ -7681,20 +7681,22 @@ async function run() {
  */
 async function pull() {
     const tagsToTry = [getTagForRun(), 'latest'];
-    const stages = getAllStages();
-    stages.forEach(async (stage) => {
+    for (const stage of getAllStages()) {
         for (const tag of tagsToTry) {
             const taggedName = getTaggedImageForStage(stage, tag);
             try {
-                // FIXME: remove try/catch & examine exit code
-                await runDockerCommand('pull', taggedName);
-                return;
+                // FIXME: remove try/catch once command stops throwing
+                const ret = await runDockerCommand('pull', taggedName);
+                if (ret.exitCode === 0) {
+                    // Do not try other tags for this stage
+                    break;
+                }
             }
             catch (error) {
                 // No-op, pull is allowed to fail
             }
         }
-    });
+    }
 }
 async function build() {
     const stages = getBaseStages();

--- a/dist/index.js
+++ b/dist/index.js
@@ -7650,8 +7650,12 @@ function getTaggedImageForStage(stage, tag) {
     return `${image}:${tag}`;
 }
 async function runDockerCommand(command, ...args) {
-    const quiet = core.getBooleanInput('quiet') ? '--quiet' : '';
-    const exitCode = await (0,exec.exec)('docker', [command, quiet, ...args]);
+    let rest = [command];
+    if (core.getBooleanInput('quiet')) {
+        rest.push('--quiet');
+    }
+    rest.push(...args);
+    const exitCode = await (0,exec.exec)('docker', rest);
     return {
         exitCode,
     };

--- a/dist/index.js
+++ b/dist/index.js
@@ -7801,8 +7801,7 @@ async function tagCommit(maybeTaggedImage, tag) {
 function getAllPossibleCacheTargets() {
     const tags = [getTagForRun(), 'latest'];
     const stages = getAllStages();
-    const out = stages.map(getUntaggedImageForStage)
-        .flatMap(image => tags.map(tag => `${image}:${tag}`));
+    const out = stages.flatMap((stage) => tags.map((tag) => getTaggedImageForStage(stage, tag)));
     return new Set(out);
 }
 run();

--- a/dist/index.js
+++ b/dist/index.js
@@ -7751,7 +7751,7 @@ async function buildStage(stage, extraTags) {
     core.startGroup(`Building stage: ${stage}`);
     const dockerfile = core.getInput('dockerfile');
     const targetTag = getTaggedImageForStage(stage, getTagForRun());
-    const cacheFromArg = Array.from(getAllPossibleCacheTargets())
+    const cacheFromArg = getAllPossibleCacheTargets()
         .flatMap(target => ['--cache-from', target]);
     const result = await runDockerCommand('build', 
     // '--build-arg', 'BUILDKIT_INLINE_CACHE="1"',
@@ -7785,8 +7785,7 @@ async function addTagAndPush(image, stage, tag) {
 function getAllPossibleCacheTargets() {
     const tags = [getTagForRun(), 'latest'];
     const stages = getAllStages();
-    const out = stages.flatMap((stage) => tags.map((tag) => getTaggedImageForStage(stage, tag)));
-    return new Set(out);
+    return stages.flatMap((stage) => tags.map((tag) => getTaggedImageForStage(stage, tag)));
 }
 run();
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -7686,7 +7686,7 @@ async function pull() {
                 runDockerCommand('pull', taggedName);
                 return;
             }
-            catch {
+            catch (error) {
                 // No-op, pull is allowed to fail
             }
         }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -56,7 +56,7 @@ export function getAllStages(): string[] {
 /**
  * Takes the build stage and returns an untagged image name for it
  */
-export function getUntaggedImageForStage(stage: string): string {
+function getUntaggedImageForStage(stage: string): string {
   const repo = core.getInput('repository')
   return `${repo}/${stage}`
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -73,8 +73,12 @@ interface ExecResult {
 }
 
 export async function runDockerCommand(command: DockerCommand, ...args: string[]): Promise<ExecResult> {
-  const quiet = core.getBooleanInput('quiet') ? '--quiet' : ''
-  const exitCode = await exec('docker', [command, quiet, ...args])
+  let rest: string[] = [command]
+  if (core.getBooleanInput('quiet')) {
+    rest.push('--quiet')
+  }
+  rest.push(...args)
+  const exitCode = await exec('docker', rest)
 
   return {
     exitCode,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -73,7 +73,7 @@ interface ExecResult {
 }
 
 export async function runDockerCommand(command: DockerCommand, ...args: string[]): Promise<ExecResult> {
-  const quiet = core.getInput('quiet') ? '--quiet' : ''
+  const quiet = core.getBooleanInput('quiet') ? '--quiet' : ''
   const exitCode = await exec('docker', [command, quiet, ...args])
 
   return {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -56,9 +56,14 @@ export function getAllStages(): string[] {
 /**
  * Takes the build stage and returns an untagged image name for it
  */
-export function getImageForStage(stage: string): string {
+export function getUntaggedImageForStage(stage: string): string {
   const repo = core.getInput('repository')
   return `${repo}/${stage}`
+}
+
+export function getTaggedImageForStage(stage: string, tag: string): string {
+  const image = getUntaggedImageForStage(stage)
+  return `${image}:${tag}`
 }
 
 type DockerCommand = 'pull' | 'push' | 'build' | 'tag'

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -46,3 +46,11 @@ export function getAllStages(): string[] {
     core.getInput('testenv-stage').trim(),
   ]
 }
+
+/**
+ * Takes the build stage and returns an untagged image name for it
+ */
+export function getImageForStage(stage: string): string {
+  const repo = core.getInput('repository')
+  return `${repo}/${stage}`
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,5 @@
 import * as core from '@actions/core'
+import { exec } from '@actions/exec'
 import * as github from '@actions/github'
 
 // Returns a string like "refs_pull_1_merge-bk1"
@@ -58,4 +59,19 @@ export function getAllStages(): string[] {
 export function getImageForStage(stage: string): string {
   const repo = core.getInput('repository')
   return `${repo}/${stage}`
+}
+
+type DockerCommand = 'pull' | 'push' | 'build' | 'tag'
+
+interface ExecResult {
+  exitCode: number
+}
+
+export async function runDockerCommand(command: DockerCommand, ...args: string[]): Promise<ExecResult> {
+  const quiet = core.getInput('quiet') ? '--quiet' : ''
+  const exitCode = await exec('docker', [command, quiet, ...args])
+
+  return {
+    exitCode,
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,16 +32,12 @@ async function pull(): Promise<void> {
   for (const stage of getAllStages()) {
     for (const tag of tagsToTry) {
       const taggedName = getTaggedImageForStage(stage, tag)
-      try {
-        // FIXME: remove try/catch once command stops throwing
-        const ret = await runDockerCommand('pull', taggedName)
-        if (ret.exitCode === 0) {
-          // Do not try other tags for this stage
-          break
-        }
-      } catch (error) {
-        // No-op, pull is allowed to fail
+      const ret = await runDockerCommand('pull', taggedName)
+      if (ret.exitCode === 0) {
+        // Do not try other tags for this stage
+        break
       }
+      // keep trying other tags for this stage
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,12 +30,12 @@ async function pull(): Promise<void> {
   const tagsToTry = [getTagForRun(), 'latest']
 
   const stages = getAllStages()
-  stages.forEach((stage) => {
+  stages.forEach(async (stage) => {
     for (const tag of tagsToTry) {
       const taggedName = getTaggedImageForStage(stage, tag)
       try {
         // FIXME: remove try/catch & examine exit code
-        runDockerCommand('pull', taggedName)
+        await runDockerCommand('pull', taggedName)
         return
       } catch (error) {
         // No-op, pull is allowed to fail

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
   getTagForRun,
   getBaseStages,
   getAllStages,
+  getImageForStage,
 } from './helpers'
 
 async function run(): Promise<void> {
@@ -59,12 +60,9 @@ async function build(): Promise<void> {
 async function buildStage(stage: string): Promise<string> {
   core.info(`Building stage ${stage}`)
 
-  const repo = core.getInput('repository')
-
-
   const quiet = core.getInput('quiet') ? '--quiet' : ''
 
-  const name = `${repo}/${stage}`
+  const name = getImageForStage(stage)
   const tagForRun = getTagForRun()
   const tagsToTry = [tagForRun, 'latest']
   // let cacheImage = ''
@@ -159,13 +157,11 @@ async function tagCommit(maybeTaggedImage: string, tag?: string): Promise<string
 function getAllPossibleCacheTargets(): Set<string> {
   const tags = [getTagForRun(), 'latest']
   const stages = getAllStages()
-  const repo = core.getInput('repository')
 
-  const out = stages.map(stage => `${repo}/${stage}`)
+  const out = stages.map(getImageForStage)
     .flatMap(image => tags.map(tag => `${image}:${tag}`))
 
   return new Set(out)
 }
-
 
 run()

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,7 +81,7 @@ async function build(): Promise<void> {
  * a tag specific to the ref/branch that the action is run on.
  */
 async function buildStage(stage: string): Promise<string> {
-  core.info(`Building stage: ${stage}`)
+  core.startGroup(`Building stage: ${stage}`)
 
   const dockerfile = core.getInput('dockerfile')
 
@@ -103,6 +103,7 @@ async function buildStage(stage: string): Promise<string> {
     throw 'Docker build failed'
   }
   dockerPush(targetTag)
+  core.endGroup()
   return targetTag
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,13 +110,13 @@ async function buildStage(stage: string): Promise<string> {
   return targetTag
 }
 
-async function dockerPush(tag: string): Promise<void> {
-  core.debug(`Pushing ${tag}`)
+async function dockerPush(taggedImage: string): Promise<void> {
+  core.debug(`Pushing ${taggedImage}`)
   const quiet = core.getInput('quiet') ? '--quiet' : ''
   const pushResult = await exec.exec('docker', [
     'push',
     quiet,
-    tag,
+    taggedImage,
   ])
   if (pushResult > 0) {
     throw 'Docker push failed'

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,6 @@ import {
   getBaseStages,
   getAllStages,
   getTaggedImageForStage,
-  getUntaggedImageForStage,
   runDockerCommand,
 } from './helpers'
 
@@ -153,8 +152,7 @@ function getAllPossibleCacheTargets(): Set<string> {
   const tags = [getTagForRun(), 'latest']
   const stages = getAllStages()
 
-  const out = stages.map(getUntaggedImageForStage)
-    .flatMap(image => tags.map(tag => `${image}:${tag}`))
+  const out = stages.flatMap((stage) => tags.map((tag) => getTaggedImageForStage(stage, tag)))
 
   return new Set(out)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,7 @@ async function buildStage(stage: string, extraTags: string[]): Promise<string> {
 
   const targetTag = getTaggedImageForStage(stage, getTagForRun())
 
-  const cacheFromArg = Array.from(getAllPossibleCacheTargets())
+  const cacheFromArg = getAllPossibleCacheTargets()
     .flatMap(target => ['--cache-from', target])
 
   const result = await runDockerCommand(
@@ -132,13 +132,11 @@ async function addTagAndPush(image: string, stage: string, tag: string): Promise
   return name
 }
 
-function getAllPossibleCacheTargets(): Set<string> {
+function getAllPossibleCacheTargets(): string[] {
   const tags = [getTagForRun(), 'latest']
   const stages = getAllStages()
 
-  const out = stages.flatMap((stage) => tags.map((tag) => getTaggedImageForStage(stage, tag)))
-
-  return new Set(out)
+  return stages.flatMap((stage) => tags.map((tag) => getTaggedImageForStage(stage, tag)))
 }
 
 run()

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,19 +29,21 @@ async function run(): Promise<void> {
 async function pull(): Promise<void> {
   const tagsToTry = [getTagForRun(), 'latest']
 
-  const stages = getAllStages()
-  stages.forEach(async (stage) => {
+  for (const stage of getAllStages()) {
     for (const tag of tagsToTry) {
       const taggedName = getTaggedImageForStage(stage, tag)
       try {
-        // FIXME: remove try/catch & examine exit code
-        await runDockerCommand('pull', taggedName)
-        return
+        // FIXME: remove try/catch once command stops throwing
+        const ret = await runDockerCommand('pull', taggedName)
+        if (ret.exitCode === 0) {
+          // Do not try other tags for this stage
+          break
+        }
       } catch (error) {
         // No-op, pull is allowed to fail
       }
     }
-  })
+  }
 }
 
 async function build(): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ async function pull(): Promise<void> {
         // FIXME: remove try/catch & examine exit code
         runDockerCommand('pull', taggedName)
         return
-      } catch {
+      } catch (error) {
         // No-op, pull is allowed to fail
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,8 +14,8 @@ import {
 
 async function run(): Promise<void> {
   try {
-    await pull()
-    await build()
+    await core.group('Pull images for layer cache', pull)
+    await core.group('Build', build)
   } catch (error) {
     core.setFailed(error.message)
   }
@@ -86,7 +86,7 @@ async function build(): Promise<void> {
  * a tag specific to the ref/branch that the action is run on.
  */
 async function buildStage(stage: string): Promise<string> {
-  core.info(`Building stage ${stage}`)
+  core.info(`Building stage: ${stage}`)
 
   const dockerfile = core.getInput('dockerfile')
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import * as core from '@actions/core'
-import * as exec from '@actions/exec'
 
 import {
   isDefaultBranch,
@@ -41,46 +40,47 @@ async function pull(): Promise<void> {
   }
 }
 
+/**
+ * Builds to all of the stages specified by the action's inputs, using the
+ * previously-pulled images for layer caching.
+ */
 async function build(): Promise<void> {
+  // Build all of the base stages
   const stages = getBaseStages()
   for (const stage of stages) {
-    await buildStage(stage)
+    // Always keep intermediate stages up to date on `latest`; this allows new
+    // branches to have a reasonable chance at a cache hit
+    await buildStage(stage, isDefaultBranch() ? ['latest'] : [])
   }
 
-  // TODO: refactor these, possibly parallelize
+  const hash = getFullCommitHash()
+  const extraTags = [hash]
+  if (isDefaultBranch() && core.getBooleanInput('tag-latest-on-default')) {
+    extraTags.push('latest')
+  }
+
+  // Build test env if the stage is specified
   const testStage = core.getInput('testenv-stage').trim()
   if (testStage === '') {
     core.info('testenv-stage not set; skipping build')
   } else {
-    // Tag the branch tag & add the commit tag
-    const testTagBranch = await buildStage(testStage)
-    const testTag = await tagCommit(testTagBranch)
-    await dockerPush(testTag)
-    core.setOutput('testenv-tag', testTag)
+    await buildStage(testStage, extraTags)
+    core.setOutput('testenv-tag', getTaggedImageForStage(testStage, hash))
   }
 
-  // Tag the branch tag & add the commit tag
+  // Build the server env
   const serverStage = core.getInput('server-stage').trim()
-  const serverTagBranch = await buildStage(serverStage)
-  const serverTag = await tagCommit(serverTagBranch)
-  await dockerPush(serverTag)
+  await buildStage(serverStage, extraTags)
+  core.setOutput('server-tag', getTaggedImageForStage(serverStage, hash))
 
-  if (core.getBooleanInput('tag-latest-on-default') && isDefaultBranch()) {
-    core.info('Creating `latest` tag for default branch')
-    const latestTag = await tagCommit(serverTagBranch, 'latest')
-    await dockerPush(latestTag)
-  }
-
-
-  core.setOutput('commit', getFullCommitHash())
-  core.setOutput('server-tag', serverTag)
+  core.setOutput('commit', hash)
 }
 
 /**
  * Runs docker build commands targeting the specified stage, and returns
  * a tag specific to the ref/branch that the action is run on.
  */
-async function buildStage(stage: string): Promise<string> {
+async function buildStage(stage: string, extraTags: string[]): Promise<string> {
   core.startGroup(`Building stage: ${stage}`)
 
   const dockerfile = core.getInput('dockerfile')
@@ -103,6 +103,10 @@ async function buildStage(stage: string): Promise<string> {
     throw 'Docker build failed'
   }
   dockerPush(targetTag)
+
+  for (const extraTag of extraTags) {
+    await addTagAndPush(targetTag, stage, extraTag)
+  }
   core.endGroup()
   return targetTag
 }
@@ -119,33 +123,12 @@ async function dockerPush(taggedImage: string): Promise<void> {
 }
 
 /**
- * Takes a docker image (which may or may not have a tag suffix) and adds or
- * replaces the tag component with the provided tag parameter. If one is not
- * specified, the full git commit hash is used as the tag component.
- *
- * Returns the full target image with tag.
+ * Returns the created tagged image name
  */
-async function tagCommit(maybeTaggedImage: string, tag?: string): Promise<string> {
-  if (tag === undefined) {
-    tag = getFullCommitHash()
-  }
-  core.info(`Tag component: ${tag}`)
-  // Don't use a simple ":" split since registries can specify port
-  const segments = maybeTaggedImage.split('/')
-  const lastImageSegment = segments.pop()
-  if (lastImageSegment!.includes(':')) {
-    const segmentWithoutTag = lastImageSegment!.substring(0, lastImageSegment!.indexOf(':'))
-    segments.push(`${segmentWithoutTag}:${tag}`)
-  } else {
-    segments.push(`${lastImageSegment}:${tag}`)
-  }
-
-  const name = segments.join('/')
-  await exec.exec('docker', [
-    'tag',
-    maybeTaggedImage,
-    name,
-  ])
+async function addTagAndPush(image: string, stage: string, tag: string): Promise<string> {
+  const name = getTaggedImageForStage(stage, tag)
+  await runDockerCommand('tag', image, name)
+  await runDockerCommand('push', name)
   return name
 }
 


### PR DESCRIPTION
This refactors a bunch of the internals:

- All image pulls happen at the beginning
- Application of the `--quiet` flag is centralized
- Image tagging avoids string manipulation and is instead based only on the action inputs and stage name
- Logic for which tags to add has been simplified and centralized
- Avoided a couple unnecessary data format shifts