### PR TITLE
Await push command

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7759,7 +7759,7 @@ async function buildStage(stage, extraTags) {
     if (result.exitCode > 0) {
         throw 'Docker build failed';
     }
-    dockerPush(targetTag);
+    await dockerPush(targetTag);
     for (const extraTag of extraTags) {
         await addTagAndPush(targetTag, stage, extraTag);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,7 +102,7 @@ async function buildStage(stage: string, extraTags: string[]): Promise<string> {
   if (result.exitCode > 0) {
     throw 'Docker build failed'
   }
-  dockerPush(targetTag)
+  await dockerPush(targetTag)
 
   for (const extraTag of extraTags) {
     await addTagAndPush(targetTag, stage, extraTag)


### PR DESCRIPTION
This could cause the next build to start before the previous one was finished pushing to the repository. Generally harmless, but it can lead to confusing logs.