### PR TITLE
Permit no cached stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ While the initial build will, of course, be performed from scratch, subsequent b
 | Input | Required | Default | Description |
 |---|---|---|---|
 | `repository` | **yes** | | Repository name for pushed images |
-| `stages` | **yes** | | Comma-separarted list of build stages |
+| `stages` | **yes** | | Comma-separarted list of build stages. Each of these will be an explicit cache target for subsequent builds |
 | `server-stage` | **yes** | | Name of stage for server |
 | `tag-latest-on-default` | no | `true` | Automatically create a `latest` tag when run on the default branch |
 | `testenv-stage` | no | | Name of stage for test environment |

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: Repository that all of the images and tags will pull from and push to
   stages:
     required: true
-    description: a comma-separated list of build stages
+    description: A comma-separated list of build stages
   server-stage:
     required: true
     description: Docker target for server

--- a/dist/index.js
+++ b/dist/index.js
@@ -7625,7 +7625,10 @@ function getFullCommitHash() {
     return github.context.sha;
 }
 function getBaseStages() {
-    return core.getInput('stages').split(',').map(stage => stage.trim());
+    return core.getInput('stages')
+        .split(',')
+        .map(stage => stage.trim())
+        .filter(stage => stage !== '');
 }
 function getAllStages() {
     const stages = [
@@ -7718,6 +7721,9 @@ async function pull() {
 async function build() {
     // Build all of the base stages
     const stages = getBaseStages();
+    if (stages.length === 0) {
+        core.warning("No base stages included - build process will have limited caching");
+    }
     for (const stage of stages) {
         // Always keep intermediate stages up to date on `latest`; this allows new
         // branches to have a reasonable chance at a cache hit

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -37,7 +37,10 @@ export function getFullCommitHash(): string {
 }
 
 export function getBaseStages(): string[] {
-  return core.getInput('stages').split(',').map(stage => stage.trim())
+  return core.getInput('stages')
+    .split(',')
+    .map(stage => stage.trim())
+    .filter(stage => stage !== '')
 }
 
 export function getAllStages(): string[] {

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,9 @@ async function pull(): Promise<void> {
 async function build(): Promise<void> {
   // Build all of the base stages
   const stages = getBaseStages()
+  if (stages.length === 0) {
+    core.warning("No base stages included - build process will have limited caching")
+  }
   for (const stage of stages) {
     // Always keep intermediate stages up to date on `latest`; this allows new
     // branches to have a reasonable chance at a cache hit


### PR DESCRIPTION
This marginally defeats the primary use-case of this action, but permits using it consistently across services even where it's not strictly beneficial for build performance (and you still get the consistent tagging and one-step build and push).