### PR TITLE
Support context

### DIFF
--- a/.github/workflows/self-test-multistage-docker-build.yml
+++ b/.github/workflows/self-test-multistage-docker-build.yml
@@ -103,6 +103,9 @@ jobs:
           echo "Testenv: ${{ steps.build.outputs.testenv-tag }}"
           echo "Commit: ${{ steps.build.outputs.commit }}"
 
+      - name: Run image
+        run: docker run --rm ${{ steps.build.outputs.server-tag }}
+
   build-different-context:
     name: Override context
     runs-on: ubuntu-latest

--- a/.github/workflows/self-test-multistage-docker-build.yml
+++ b/.github/workflows/self-test-multistage-docker-build.yml
@@ -133,4 +133,4 @@ jobs:
           echo "Commit: ${{ steps.build.outputs.commit }}"
 
       - name: Run image
-        run: docker exec --rm ${{ steps.build.outputs.server }}
+        run: docker run --rm ${{ steps.build.outputs.server-tag }}

--- a/.github/workflows/self-test-multistage-docker-build.yml
+++ b/.github/workflows/self-test-multistage-docker-build.yml
@@ -102,3 +102,32 @@ jobs:
           echo "Server: ${{ steps.build.outputs.server-tag }}"
           echo "Testenv: ${{ steps.build.outputs.testenv-tag }}"
           echo "Commit: ${{ steps.build.outputs.commit }}"
+
+  build-different-context:
+    name: Override context
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Auth to GH registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ./
+        name: Build with this action
+        id: build
+        with:
+          context: examples
+          dockerfile: examples/Dockerfile
+          repository: ghcr.io/firehed/actions
+          stages: env, configured
+          server-stage: server
+
+      - name: Print outputs
+        run: |
+          echo "Server: ${{ steps.build.outputs.server-tag }}"
+          echo "Testenv: ${{ steps.build.outputs.testenv-tag }}"
+          echo "Commit: ${{ steps.build.outputs.commit }}"

--- a/.github/workflows/self-test-multistage-docker-build.yml
+++ b/.github/workflows/self-test-multistage-docker-build.yml
@@ -131,3 +131,6 @@ jobs:
           echo "Server: ${{ steps.build.outputs.server-tag }}"
           echo "Testenv: ${{ steps.build.outputs.testenv-tag }}"
           echo "Commit: ${{ steps.build.outputs.commit }}"
+
+      - name: Run image
+        run: docker exec --rm ${{ steps.build.outputs.server }}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ While the initial build will, of course, be performed from scratch, subsequent b
 | `server-stage` | **yes** | | Name of stage for server |
 | `tag-latest-on-default` | no | `true` | Automatically create a `latest` tag when run on the default branch |
 | `testenv-stage` | no | | Name of stage for test environment |
+| `context` | no | `.` | Build context |
 | `dockerfile` | no | `Dockerfile` | Path to the Dockerfile |
 | `quiet` | no | `true` | Should docker commands be passed `--quiet` |
 | `build-args` | no | | Comma-separated list of `--build-arg` flags. |

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: A comma-separated list of `--build-arg` flags
     required: false
     default: ''
+  context:
+    description: Build context. Default to `.`
+    required: false
+    default: '.'
   dockerfile:
     description: Path to Dockerfile
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -7796,7 +7796,7 @@ async function buildStage(stage, extraTags) {
             .flatMap(arg => ['--build-arg', arg]);
         const result = await runDockerCommand('build', 
         // '--build-arg', 'BUILDKIT_INLINE_CACHE="1"',
-        ...buildArgs, ...cacheFromArg, '--file', dockerfile, '--tag', targetTag, '--target', stage, '.');
+        ...buildArgs, ...cacheFromArg, '--file', dockerfile, '--tag', targetTag, '--target', stage, core.getInput('context'));
         if (result.exitCode > 0) {
             throw 'Docker build failed';
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,7 @@ async function buildStage(stage: string, extraTags: string[]): Promise<string> {
       '--file', dockerfile,
       '--tag', targetTag,
       '--target', stage,
-      '.'
+      core.getInput('context'),
     )
     if (result.exitCode > 0) {
       throw 'Docker build failed'


### PR DESCRIPTION
Allow customizing the build context, i.e. the final argument passed to `docker build`. Still defaults to `.`.

The most straightforward use-case is builds in a monorepo subdirectory, but the possibilities are limitless!