### PR TITLE
Fix path collision when using context

### DIFF
--- a/.github/workflows/self-test-multistage-docker-build.yml
+++ b/.github/workflows/self-test-multistage-docker-build.yml
@@ -124,6 +124,37 @@ jobs:
         id: build
         with:
           context: examples
+          repository: ghcr.io/firehed/actions
+          stages: env, configured
+          server-stage: server
+
+      - name: Print outputs
+        run: |
+          echo "Server: ${{ steps.build.outputs.server-tag }}"
+          echo "Testenv: ${{ steps.build.outputs.testenv-tag }}"
+          echo "Commit: ${{ steps.build.outputs.commit }}"
+
+      - name: Run image
+        run: docker run --rm ${{ steps.build.outputs.server-tag }}
+
+  build-different-context-and-dockerfile:
+    name: Override context and file
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Auth to GH registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ./
+        name: Build with this action
+        id: build
+        with:
+          context: examples
           dockerfile: examples/Dockerfile
           repository: ghcr.io/firehed/actions
           stages: env, configured

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
   dockerfile:
     description: Path to Dockerfile
     required: false
-    default: Dockerfile
+    default: ''
   repository:
     required: true
     description: Repository that all of the images and tags will pull from and push to

--- a/dist/index.js
+++ b/dist/index.js
@@ -7789,6 +7789,7 @@ async function buildStage(stage, extraTags) {
     return time(`Build ${stage}`, async () => {
         core.startGroup(`Building stage: ${stage}`);
         const dockerfile = core.getInput('dockerfile');
+        const dockerfileArg = (dockerfile === '') ? [] : ['--file', dockerfile];
         const targetTag = getTaggedImageForStage(stage, getTagForRun());
         const cacheFromArg = getAllPossibleCacheTargets()
             .flatMap(target => ['--cache-from', target]);
@@ -7796,7 +7797,7 @@ async function buildStage(stage, extraTags) {
             .flatMap(arg => ['--build-arg', arg]);
         const result = await runDockerCommand('build', 
         // '--build-arg', 'BUILDKIT_INLINE_CACHE="1"',
-        ...buildArgs, ...cacheFromArg, '--file', dockerfile, '--tag', targetTag, '--target', stage, core.getInput('context'));
+        ...buildArgs, ...cacheFromArg, ...dockerfileArg, '--tag', targetTag, '--target', stage, core.getInput('context'));
         if (result.exitCode > 0) {
             throw 'Docker build failed';
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,7 @@ async function buildStage(stage: string, extraTags: string[]): Promise<string> {
     core.startGroup(`Building stage: ${stage}`)
 
     const dockerfile = core.getInput('dockerfile')
+    const dockerfileArg = (dockerfile === '') ? [] : ['--file', dockerfile]
 
     const targetTag = getTaggedImageForStage(stage, getTagForRun())
 
@@ -106,7 +107,7 @@ async function buildStage(stage: string, extraTags: string[]): Promise<string> {
       // '--build-arg', 'BUILDKIT_INLINE_CACHE="1"',
       ...buildArgs,
       ...cacheFromArg,
-      '--file', dockerfile,
+      ...dockerfileArg,
       '--tag', targetTag,
       '--target', stage,
       core.getInput('context'),


### PR DESCRIPTION
In v1.5.0, if `context` is provided without `dockerfile`, it would still run with `--file Dockerfile`, which does NOT match the default behavior of a Docker build. This tweaks the build args to only pass the `--file` argument if it was explicitly provided. Consequently, builds of a subdirectory (etc) w/out giving a path to the dockerfile should work by default.