### PR TITLE
Support parallel builds (via buildx)

### DIFF
--- a/.github/workflows/self-test-multistage-docker-build.yml
+++ b/.github/workflows/self-test-multistage-docker-build.yml
@@ -30,11 +30,6 @@ jobs:
       - name: generate file change
         run: echo $GITHUB_SHA > file.txt
 
-      - run: docker buildx version
-      - run: docker buildx help
-      - run: docker buildx build --help
-      - run: docker buildx build --build-arg BUILD_ARG_1=hello --cache-from ghcr.io/firehed/actions/server:refs_pull_39_merge-bk1 --cache-from ghcr.io/firehed/actions/server:latest --file examples/Dockerfile --tag ghcr.io/firehed/actions/server:refs_pull_39_merge-bk1 --target server .
-
       - uses: ./
         id: build
         with:

--- a/.github/workflows/self-test-multistage-docker-build.yml
+++ b/.github/workflows/self-test-multistage-docker-build.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: ./
         id: build
         with:
-          build-args: BUILD_ARG_1=hello, BUILD_ARG_2=goodbye, version=${{ github.sha }}
+          build-args: BUILD_ARG_1=hello
           dockerfile: examples/Dockerfile
           repository: ghcr.io/firehed/actions
           server-stage: server

--- a/.github/workflows/self-test-multistage-docker-build.yml
+++ b/.github/workflows/self-test-multistage-docker-build.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   test-build-parallel-setting:
+    name: Parallel via setting
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -42,6 +43,7 @@ jobs:
           quiet: false
 
   test-build-parallel-buildkit:
+    name: Parallel via DOCKER_BUILDKIT
     runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: "1"
@@ -66,7 +68,6 @@ jobs:
           repository: ghcr.io/firehed/actions
           server-stage: server
           quiet: false
-
 
   build:
     name: Build docker images

--- a/.github/workflows/self-test-multistage-docker-build.yml
+++ b/.github/workflows/self-test-multistage-docker-build.yml
@@ -13,18 +13,10 @@ permissions:
   packages: write
 
 jobs:
-  build:
-    name: Build docker images
+  test-build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        buildkit: ["0", "1"]
     env:
-      DOCKER_BUILDKIT: ${{ matrix.buildkit }}
-
-    outputs:
-      testenv-tag: ${{ steps.build.outputs.testenv-tag }}
-      server-tag: ${{ steps.build.outputs.server-tag }}
+      DOCKER_BUILDKIT: "1"
     steps:
       - uses: actions/checkout@v3
 
@@ -43,183 +35,218 @@ jobs:
         with:
           build-args: BUILD_ARG_1=hello, BUILD_ARG_2=goodbye, version=${{ github.sha }}
           dockerfile: examples/Dockerfile
-          # repository: firehed/actions
-          # repository: gcr.io/firehed/actions
           repository: ghcr.io/firehed/actions
-          stages: env, configured
-          testenv-stage: testenv
           server-stage: server
           quiet: false
 
-  test:
-    name: 'test'
-    runs-on: ubuntu-latest
-    needs:
-      - build
-    steps:
-      - name: run tests
-        run:
-          docker run
-            --rm
-            ${{ needs.build.outputs.testenv-tag }}
-            echo "I'm a test!"
 
-      - name: get build arg1
-        id: build-args
-        run: docker run
-            --rm
-            ${{ needs.build.outputs.testenv-tag }}
-            sh examples/print-outputs.sh
+#   build:
+#     name: Build docker images
+#     runs-on: ubuntu-latest
+#     strategy:
+#       matrix:
+#         buildkit: ["0", "1"]
+#     env:
+#       DOCKER_BUILDKIT: ${{ matrix.buildkit }}
 
-      - name: validate build arg 1
-        if: ${{ steps.build-args.outputs.arg1 != 'hello' }}
-        run: exit 1
+#     outputs:
+#       testenv-tag: ${{ steps.build.outputs.testenv-tag }}
+#       server-tag: ${{ steps.build.outputs.server-tag }}
+#     steps:
+#       - uses: actions/checkout@v3
 
-      - name: validate build arg 2
-        if: ${{ steps.build-args.outputs.arg2 != 'goodbye' }}
-        run: exit 1
+#       - name: Auth to GH registry
+#         uses: docker/login-action@v2
+#         with:
+#           registry: ghcr.io
+#           username: ${{ github.repository_owner }}
+#           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: display server
-        run: echo ${{ needs.build.outputs.server-tag }}
+#       - name: generate file change
+#         run: echo $GITHUB_SHA > file.txt
 
-  build-server-only:
-    name: Build server image only
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
+#       - uses: ./
+#         id: build
+#         with:
+#           build-args: BUILD_ARG_1=hello, BUILD_ARG_2=goodbye, version=${{ github.sha }}
+#           dockerfile: examples/Dockerfile
+#           # repository: firehed/actions
+#           # repository: gcr.io/firehed/actions
+#           repository: ghcr.io/firehed/actions
+#           stages: env, configured
+#           testenv-stage: testenv
+#           server-stage: server
+#           quiet: false
 
-      - name: Auth to GH registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+#   test:
+#     name: 'test'
+#     runs-on: ubuntu-latest
+#     needs:
+#       - build
+#     steps:
+#       - name: run tests
+#         run:
+#           docker run
+#             --rm
+#             ${{ needs.build.outputs.testenv-tag }}
+#             echo "I'm a test!"
 
-      - uses: ./
-        id: build
-        with:
-          dockerfile: examples/Dockerfile
-          repository: ghcr.io/firehed/actions
-          stages: env, configured
-          server-stage: server
+#       - name: get build arg1
+#         id: build-args
+#         run: docker run
+#             --rm
+#             ${{ needs.build.outputs.testenv-tag }}
+#             sh examples/print-outputs.sh
 
-      - name: Print outputs
-        run: |
-          echo "Server: ${{ steps.build.outputs.server-tag }}"
-          echo "Testenv: ${{ steps.build.outputs.testenv-tag }}"
-          echo "Commit: ${{ steps.build.outputs.commit }}"
+#       - name: validate build arg 1
+#         if: ${{ steps.build-args.outputs.arg1 != 'hello' }}
+#         run: exit 1
 
-      - name: Run image
-        run: docker run --rm ${{ steps.build.outputs.server-tag }}
+#       - name: validate build arg 2
+#         if: ${{ steps.build-args.outputs.arg2 != 'goodbye' }}
+#         run: exit 1
 
-  build-different-context:
-    name: Override context
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
+#       - name: display server
+#         run: echo ${{ needs.build.outputs.server-tag }}
 
-      - name: Auth to GH registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+#   build-server-only:
+#     name: Build server image only
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v3
 
-      - uses: ./
-        name: Build with this action
-        id: build
-        with:
-          context: examples
-          repository: ghcr.io/firehed/actions
-          stages: env, configured
-          server-stage: server
+#       - name: Auth to GH registry
+#         uses: docker/login-action@v2
+#         with:
+#           registry: ghcr.io
+#           username: ${{ github.repository_owner }}
+#           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Print outputs
-        run: |
-          echo "Server: ${{ steps.build.outputs.server-tag }}"
-          echo "Testenv: ${{ steps.build.outputs.testenv-tag }}"
-          echo "Commit: ${{ steps.build.outputs.commit }}"
+#       - uses: ./
+#         id: build
+#         with:
+#           dockerfile: examples/Dockerfile
+#           repository: ghcr.io/firehed/actions
+#           stages: env, configured
+#           server-stage: server
 
-      - name: Run image
-        run: docker run --rm ${{ steps.build.outputs.server-tag }}
+#       - name: Print outputs
+#         run: |
+#           echo "Server: ${{ steps.build.outputs.server-tag }}"
+#           echo "Testenv: ${{ steps.build.outputs.testenv-tag }}"
+#           echo "Commit: ${{ steps.build.outputs.commit }}"
 
-  build-different-context-and-dockerfile:
-    name: Override context and file
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
+#       - name: Run image
+#         run: docker run --rm ${{ steps.build.outputs.server-tag }}
 
-      - name: Auth to GH registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+#   build-different-context:
+#     name: Override context
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v3
 
-      - uses: ./
-        name: Build with this action
-        id: build
-        with:
-          context: examples
-          dockerfile: examples/Dockerfile
-          repository: ghcr.io/firehed/actions
-          stages: env, configured
-          server-stage: server
+#       - name: Auth to GH registry
+#         uses: docker/login-action@v2
+#         with:
+#           registry: ghcr.io
+#           username: ${{ github.repository_owner }}
+#           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Print outputs
-        run: |
-          echo "Server: ${{ steps.build.outputs.server-tag }}"
-          echo "Testenv: ${{ steps.build.outputs.testenv-tag }}"
-          echo "Commit: ${{ steps.build.outputs.commit }}"
+#       - uses: ./
+#         name: Build with this action
+#         id: build
+#         with:
+#           context: examples
+#           repository: ghcr.io/firehed/actions
+#           stages: env, configured
+#           server-stage: server
 
-      - name: Run image
-        run: docker run --rm ${{ steps.build.outputs.server-tag }}
+#       - name: Print outputs
+#         run: |
+#           echo "Server: ${{ steps.build.outputs.server-tag }}"
+#           echo "Testenv: ${{ steps.build.outputs.testenv-tag }}"
+#           echo "Commit: ${{ steps.build.outputs.commit }}"
 
-  expect-error-build-failure:
-    name: Action should fail if docker build fails
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
+#       - name: Run image
+#         run: docker run --rm ${{ steps.build.outputs.server-tag }}
 
-      - name: Auth to GH registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+#   build-different-context-and-dockerfile:
+#     name: Override context and file
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v3
 
-      - uses: ./
-        name: Build with bad settings
-        continue-on-error: true
-        id: build
-        with:
-          # No context/dockerfile
-          server-stage: server
-          repository: ghcr.io/firehed/actions
+#       - name: Auth to GH registry
+#         uses: docker/login-action@v2
+#         with:
+#           registry: ghcr.io
+#           username: ${{ github.repository_owner }}
+#           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: expect failure
-        if: steps.build.outcome == 'success'
-        run: exit 1
+#       - uses: ./
+#         name: Build with this action
+#         id: build
+#         with:
+#           context: examples
+#           dockerfile: examples/Dockerfile
+#           repository: ghcr.io/firehed/actions
+#           stages: env, configured
+#           server-stage: server
+
+#       - name: Print outputs
+#         run: |
+#           echo "Server: ${{ steps.build.outputs.server-tag }}"
+#           echo "Testenv: ${{ steps.build.outputs.testenv-tag }}"
+#           echo "Commit: ${{ steps.build.outputs.commit }}"
+
+#       - name: Run image
+#         run: docker run --rm ${{ steps.build.outputs.server-tag }}
+
+#   expect-error-build-failure:
+#     name: Action should fail if docker build fails
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v3
+
+#       - name: Auth to GH registry
+#         uses: docker/login-action@v2
+#         with:
+#           registry: ghcr.io
+#           username: ${{ github.repository_owner }}
+#           password: ${{ secrets.GITHUB_TOKEN }}
+
+#       - uses: ./
+#         name: Build with bad settings
+#         continue-on-error: true
+#         id: build
+#         with:
+#           # No context/dockerfile
+#           server-stage: server
+#           repository: ghcr.io/firehed/actions
+
+#       - name: expect failure
+#         if: steps.build.outcome == 'success'
+#         run: exit 1
 
 
-  expect-error-push-failure:
-    name: Action should fail if docker push fails
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
+#   expect-error-push-failure:
+#     name: Action should fail if docker push fails
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v3
 
-      # Do not log in to docker registry. This will cause the push to fail
+#       # Do not log in to docker registry. This will cause the push to fail
 
-      - uses: ./
-        name: Build without login
-        continue-on-error: true
-        id: build
-        with:
-          context: examples
-          repository: ghcr.io/firehed/actions
-          stages: env, configured
-          server-stage: server
+#       - uses: ./
+#         name: Build without login
+#         continue-on-error: true
+#         id: build
+#         with:
+#           context: examples
+#           repository: ghcr.io/firehed/actions
+#           stages: env, configured
+#           server-stage: server
 
-      - name: expect failure
-        if: steps.build.outcome == 'success'
-        run: exit 1
+#       - name: expect failure
+#         if: steps.build.outcome == 'success'
+#         run: exit 1

--- a/.github/workflows/self-test-multistage-docker-build.yml
+++ b/.github/workflows/self-test-multistage-docker-build.yml
@@ -33,6 +33,7 @@ jobs:
       - run: docker buildx version
       - run: docker buildx help
       - run: docker buildx build --help
+      - run: docker buildx build --build-arg BUILD_ARG_1=hello --cache-from ghcr.io/firehed/actions/server:refs_pull_39_merge-bk1 --cache-from ghcr.io/firehed/actions/server:latest --file examples/Dockerfile --tag ghcr.io/firehed/actions/server:refs_pull_39_merge-bk1 --target server .
 
       - uses: ./
         id: build

--- a/.github/workflows/self-test-multistage-docker-build.yml
+++ b/.github/workflows/self-test-multistage-docker-build.yml
@@ -13,7 +13,35 @@ permissions:
   packages: write
 
 jobs:
-  test-build:
+  test-build-parallel-setting:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        parallel: [true, false]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Auth to GH registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: generate file change
+        run: echo $GITHUB_SHA > file.txt
+
+      - uses: ./
+        id: build
+        with:
+          build-args: BUILD_ARG_1=hello
+          dockerfile: examples/Dockerfile
+          repository: ghcr.io/firehed/actions
+          parallel: ${{ matrix.parallel }}
+          server-stage: server
+          quiet: false
+
+  test-build-parallel-buildkit:
     runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: "1"

--- a/.github/workflows/self-test-multistage-docker-build.yml
+++ b/.github/workflows/self-test-multistage-docker-build.yml
@@ -30,6 +30,10 @@ jobs:
       - name: generate file change
         run: echo $GITHUB_SHA > file.txt
 
+      - run: docker buildx version
+      - run: docker buildx help
+      - run: docker buildx build help
+
       - uses: ./
         id: build
         with:

--- a/.github/workflows/self-test-multistage-docker-build.yml
+++ b/.github/workflows/self-test-multistage-docker-build.yml
@@ -40,213 +40,213 @@ jobs:
           quiet: false
 
 
-#   build:
-#     name: Build docker images
-#     runs-on: ubuntu-latest
-#     strategy:
-#       matrix:
-#         buildkit: ["0", "1"]
-#     env:
-#       DOCKER_BUILDKIT: ${{ matrix.buildkit }}
+  build:
+    name: Build docker images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        buildkit: ["0", "1"]
+    env:
+      DOCKER_BUILDKIT: ${{ matrix.buildkit }}
 
-#     outputs:
-#       testenv-tag: ${{ steps.build.outputs.testenv-tag }}
-#       server-tag: ${{ steps.build.outputs.server-tag }}
-#     steps:
-#       - uses: actions/checkout@v3
+    outputs:
+      testenv-tag: ${{ steps.build.outputs.testenv-tag }}
+      server-tag: ${{ steps.build.outputs.server-tag }}
+    steps:
+      - uses: actions/checkout@v3
 
-#       - name: Auth to GH registry
-#         uses: docker/login-action@v2
-#         with:
-#           registry: ghcr.io
-#           username: ${{ github.repository_owner }}
-#           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Auth to GH registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-#       - name: generate file change
-#         run: echo $GITHUB_SHA > file.txt
+      - name: generate file change
+        run: echo $GITHUB_SHA > file.txt
 
-#       - uses: ./
-#         id: build
-#         with:
-#           build-args: BUILD_ARG_1=hello, BUILD_ARG_2=goodbye, version=${{ github.sha }}
-#           dockerfile: examples/Dockerfile
-#           # repository: firehed/actions
-#           # repository: gcr.io/firehed/actions
-#           repository: ghcr.io/firehed/actions
-#           stages: env, configured
-#           testenv-stage: testenv
-#           server-stage: server
-#           quiet: false
+      - uses: ./
+        id: build
+        with:
+          build-args: BUILD_ARG_1=hello, BUILD_ARG_2=goodbye, version=${{ github.sha }}
+          dockerfile: examples/Dockerfile
+          # repository: firehed/actions
+          # repository: gcr.io/firehed/actions
+          repository: ghcr.io/firehed/actions
+          stages: env, configured
+          testenv-stage: testenv
+          server-stage: server
+          quiet: false
 
-#   test:
-#     name: 'test'
-#     runs-on: ubuntu-latest
-#     needs:
-#       - build
-#     steps:
-#       - name: run tests
-#         run:
-#           docker run
-#             --rm
-#             ${{ needs.build.outputs.testenv-tag }}
-#             echo "I'm a test!"
+  test:
+    name: 'test'
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: run tests
+        run:
+          docker run
+            --rm
+            ${{ needs.build.outputs.testenv-tag }}
+            echo "I'm a test!"
 
-#       - name: get build arg1
-#         id: build-args
-#         run: docker run
-#             --rm
-#             ${{ needs.build.outputs.testenv-tag }}
-#             sh examples/print-outputs.sh
+      - name: get build arg1
+        id: build-args
+        run: docker run
+            --rm
+            ${{ needs.build.outputs.testenv-tag }}
+            sh examples/print-outputs.sh
 
-#       - name: validate build arg 1
-#         if: ${{ steps.build-args.outputs.arg1 != 'hello' }}
-#         run: exit 1
+      - name: validate build arg 1
+        if: ${{ steps.build-args.outputs.arg1 != 'hello' }}
+        run: exit 1
 
-#       - name: validate build arg 2
-#         if: ${{ steps.build-args.outputs.arg2 != 'goodbye' }}
-#         run: exit 1
+      - name: validate build arg 2
+        if: ${{ steps.build-args.outputs.arg2 != 'goodbye' }}
+        run: exit 1
 
-#       - name: display server
-#         run: echo ${{ needs.build.outputs.server-tag }}
+      - name: display server
+        run: echo ${{ needs.build.outputs.server-tag }}
 
-#   build-server-only:
-#     name: Build server image only
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@v3
+  build-server-only:
+    name: Build server image only
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
 
-#       - name: Auth to GH registry
-#         uses: docker/login-action@v2
-#         with:
-#           registry: ghcr.io
-#           username: ${{ github.repository_owner }}
-#           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Auth to GH registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-#       - uses: ./
-#         id: build
-#         with:
-#           dockerfile: examples/Dockerfile
-#           repository: ghcr.io/firehed/actions
-#           stages: env, configured
-#           server-stage: server
+      - uses: ./
+        id: build
+        with:
+          dockerfile: examples/Dockerfile
+          repository: ghcr.io/firehed/actions
+          stages: env, configured
+          server-stage: server
 
-#       - name: Print outputs
-#         run: |
-#           echo "Server: ${{ steps.build.outputs.server-tag }}"
-#           echo "Testenv: ${{ steps.build.outputs.testenv-tag }}"
-#           echo "Commit: ${{ steps.build.outputs.commit }}"
+      - name: Print outputs
+        run: |
+          echo "Server: ${{ steps.build.outputs.server-tag }}"
+          echo "Testenv: ${{ steps.build.outputs.testenv-tag }}"
+          echo "Commit: ${{ steps.build.outputs.commit }}"
 
-#       - name: Run image
-#         run: docker run --rm ${{ steps.build.outputs.server-tag }}
+      - name: Run image
+        run: docker run --rm ${{ steps.build.outputs.server-tag }}
 
-#   build-different-context:
-#     name: Override context
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@v3
+  build-different-context:
+    name: Override context
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
 
-#       - name: Auth to GH registry
-#         uses: docker/login-action@v2
-#         with:
-#           registry: ghcr.io
-#           username: ${{ github.repository_owner }}
-#           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Auth to GH registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-#       - uses: ./
-#         name: Build with this action
-#         id: build
-#         with:
-#           context: examples
-#           repository: ghcr.io/firehed/actions
-#           stages: env, configured
-#           server-stage: server
+      - uses: ./
+        name: Build with this action
+        id: build
+        with:
+          context: examples
+          repository: ghcr.io/firehed/actions
+          stages: env, configured
+          server-stage: server
 
-#       - name: Print outputs
-#         run: |
-#           echo "Server: ${{ steps.build.outputs.server-tag }}"
-#           echo "Testenv: ${{ steps.build.outputs.testenv-tag }}"
-#           echo "Commit: ${{ steps.build.outputs.commit }}"
+      - name: Print outputs
+        run: |
+          echo "Server: ${{ steps.build.outputs.server-tag }}"
+          echo "Testenv: ${{ steps.build.outputs.testenv-tag }}"
+          echo "Commit: ${{ steps.build.outputs.commit }}"
 
-#       - name: Run image
-#         run: docker run --rm ${{ steps.build.outputs.server-tag }}
+      - name: Run image
+        run: docker run --rm ${{ steps.build.outputs.server-tag }}
 
-#   build-different-context-and-dockerfile:
-#     name: Override context and file
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@v3
+  build-different-context-and-dockerfile:
+    name: Override context and file
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
 
-#       - name: Auth to GH registry
-#         uses: docker/login-action@v2
-#         with:
-#           registry: ghcr.io
-#           username: ${{ github.repository_owner }}
-#           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Auth to GH registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-#       - uses: ./
-#         name: Build with this action
-#         id: build
-#         with:
-#           context: examples
-#           dockerfile: examples/Dockerfile
-#           repository: ghcr.io/firehed/actions
-#           stages: env, configured
-#           server-stage: server
+      - uses: ./
+        name: Build with this action
+        id: build
+        with:
+          context: examples
+          dockerfile: examples/Dockerfile
+          repository: ghcr.io/firehed/actions
+          stages: env, configured
+          server-stage: server
 
-#       - name: Print outputs
-#         run: |
-#           echo "Server: ${{ steps.build.outputs.server-tag }}"
-#           echo "Testenv: ${{ steps.build.outputs.testenv-tag }}"
-#           echo "Commit: ${{ steps.build.outputs.commit }}"
+      - name: Print outputs
+        run: |
+          echo "Server: ${{ steps.build.outputs.server-tag }}"
+          echo "Testenv: ${{ steps.build.outputs.testenv-tag }}"
+          echo "Commit: ${{ steps.build.outputs.commit }}"
 
-#       - name: Run image
-#         run: docker run --rm ${{ steps.build.outputs.server-tag }}
+      - name: Run image
+        run: docker run --rm ${{ steps.build.outputs.server-tag }}
 
-#   expect-error-build-failure:
-#     name: Action should fail if docker build fails
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@v3
+  expect-error-build-failure:
+    name: Action should fail if docker build fails
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
 
-#       - name: Auth to GH registry
-#         uses: docker/login-action@v2
-#         with:
-#           registry: ghcr.io
-#           username: ${{ github.repository_owner }}
-#           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Auth to GH registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-#       - uses: ./
-#         name: Build with bad settings
-#         continue-on-error: true
-#         id: build
-#         with:
-#           # No context/dockerfile
-#           server-stage: server
-#           repository: ghcr.io/firehed/actions
+      - uses: ./
+        name: Build with bad settings
+        continue-on-error: true
+        id: build
+        with:
+          # No context/dockerfile
+          server-stage: server
+          repository: ghcr.io/firehed/actions
 
-#       - name: expect failure
-#         if: steps.build.outcome == 'success'
-#         run: exit 1
+      - name: expect failure
+        if: steps.build.outcome == 'success'
+        run: exit 1
 
 
-#   expect-error-push-failure:
-#     name: Action should fail if docker push fails
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@v3
+  expect-error-push-failure:
+    name: Action should fail if docker push fails
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
 
-#       # Do not log in to docker registry. This will cause the push to fail
+      # Do not log in to docker registry. This will cause the push to fail
 
-#       - uses: ./
-#         name: Build without login
-#         continue-on-error: true
-#         id: build
-#         with:
-#           context: examples
-#           repository: ghcr.io/firehed/actions
-#           stages: env, configured
-#           server-stage: server
+      - uses: ./
+        name: Build without login
+        continue-on-error: true
+        id: build
+        with:
+          context: examples
+          repository: ghcr.io/firehed/actions
+          stages: env, configured
+          server-stage: server
 
-#       - name: expect failure
-#         if: steps.build.outcome == 'success'
-#         run: exit 1
+      - name: expect failure
+        if: steps.build.outcome == 'success'
+        run: exit 1

--- a/.github/workflows/self-test-multistage-docker-build.yml
+++ b/.github/workflows/self-test-multistage-docker-build.yml
@@ -32,7 +32,7 @@ jobs:
 
       - run: docker buildx version
       - run: docker buildx help
-      - run: docker buildx build help
+      - run: docker buildx build --help
 
       - uses: ./
         id: build

--- a/README.md
+++ b/README.md
@@ -24,7 +24,24 @@ While the action allows many stages to be pushed to the registry for future re-u
 | `context` | no | `.` | Build context |
 | `dockerfile` | no | `Dockerfile` | Path to the Dockerfile |
 | `quiet` | no | `true` | Should docker commands be passed `--quiet` |
+| `parallel` | no | `false` | Should stages be built in parallel (via BuildX) |
 | `build-args` | no | | Comma-separated list of `--build-arg` flags. |
+
+### Parallel builds
+The new `parallel` option, added in `v1.7`, defaults to off.
+In the next major version (v2), it will default to on.
+
+Changing to the opposite build mode, either implicitly or explicitly, *will break your layer cache for the first build*.
+The internal image formats are incompatible, and are tagged accordingly to avoid conflicts.
+This is a Docker limitation at this time.
+Please note that all images not produced in `outputs` (see below) are considered internal implementation details, subject to change, and **should never be deployed**.
+
+The current parallel build implementation uses `docker buildx` with very specific `--cache-from` flags to encourage layer reuse.
+Note that this is considered an internal implementation detail, and is subject to change during a minor and/or point release.
+However such a change is unlikely and will be documented.
+
+If you have explicly set `DOCKER_BUILDKIT=1` or `DOCKER_BUILDKIT=0`, it will override the input setting.
+Use of this is **not recommended**.
 
 ## Outputs
 
@@ -106,7 +123,4 @@ tl:dr: If it comes from one of the `outputs` of this action, go ahead and use it
 
 ## Known issues/Future features
 
-- Use with Docker Buildkit (via `DOCKER_BUILDKIT=1`) does not consistently use the layer caches.
-  This seems to be a Buildkit issue.
-  It's recommended to leave Buildkit disabled at this time.
 - Make a straightforward mechanism to do cleanup

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: Path to Dockerfile
     required: false
     default: ''
+  parallel:
+    description: Build in parallel
+    required: false
+    default: false
   repository:
     required: true
     description: Repository that all of the images and tags will pull from and push to

--- a/dist/index.js
+++ b/dist/index.js
@@ -10894,7 +10894,7 @@ exports.getTaggedImageForStage = getTaggedImageForStage;
 async function runDockerCommand(command, ...args) {
     const rest = [command];
     if (command === 'build' && shouldBuildInParallel()) {
-        rest.push('buildx');
+        rest.unshift('buildx');
     }
     if (core.getBooleanInput('quiet') && command !== 'tag') {
         rest.push('--quiet');

--- a/dist/index.js
+++ b/dist/index.js
@@ -11066,7 +11066,7 @@ async function buildStage(stage, extraTags) {
         const dockerfileArg = (dockerfile === '') ? [] : ['--file', dockerfile];
         const targetTag = (0, helpers_1.getTaggedImageForStage)(stage, (0, helpers_1.getTagForRun)());
         const cacheFromArg = getAllPossibleCacheTargets()
-            .flatMap(target => ['--cache-from', target]);
+            .flatMap(target => ['--cache-from', `type=registry,ref=${target}`]);
         const buildArgs = (0, helpers_1.getBuildArgs)()
             .flatMap(arg => ['--build-arg', arg]);
         if ((0, helpers_1.shouldBuildInParallel)()) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -11069,6 +11069,9 @@ async function buildStage(stage, extraTags) {
             .flatMap(target => ['--cache-from', target]);
         const buildArgs = (0, helpers_1.getBuildArgs)()
             .flatMap(arg => ['--build-arg', arg]);
+        if ((0, helpers_1.shouldBuildInParallel)()) {
+            buildArgs.push('--build-arg', 'BUILDKIT_INLINE_CACHE=1');
+        }
         const result = await (0, helpers_1.runDockerCommand)('build', 
         // '--build-arg', 'BUILDKIT_INLINE_CACHE="1"',
         ...buildArgs, ...cacheFromArg, ...dockerfileArg, '--tag', targetTag, '--target', stage, core.getInput('context'));

--- a/dist/index.js
+++ b/dist/index.js
@@ -11069,9 +11069,10 @@ async function buildStage(stage, extraTags) {
             .flatMap(target => ['--cache-from', `type=registry,ref=${target}`]);
         const buildArgs = (0, helpers_1.getBuildArgs)()
             .flatMap(arg => ['--build-arg', arg]);
-        if ((0, helpers_1.shouldBuildInParallel)()) {
-            buildArgs.push('--build-arg', 'BUILDKIT_INLINE_CACHE=1');
-        }
+        (0, helpers_1.shouldBuildInParallel)();
+        // if (shouldBuildInParallel()) {
+        //   buildArgs.push('--build-arg', 'BUILDKIT_INLINE_CACHE=1')
+        // }
         const result = await (0, helpers_1.runDockerCommand)('build', 
         // '--build-arg', 'BUILDKIT_INLINE_CACHE="1"',
         ...buildArgs, ...cacheFromArg, ...dockerfileArg, '--tag', targetTag, '--target', stage, core.getInput('context'));

--- a/dist/index.js
+++ b/dist/index.js
@@ -10893,6 +10893,7 @@ exports.getTaggedImageForStage = getTaggedImageForStage;
  */
 async function runDockerCommand(command, ...args) {
     const rest = [command];
+    core.info(JSON.stringify(args));
     if (core.getBooleanInput('quiet') && command !== 'tag') {
         rest.push('--quiet');
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -10911,7 +10911,9 @@ async function runDockerCommand(command, ...args) {
             },
         }
     };
-    const exitCode = await (0, exec_1.exec)('docker', rest, execOptions);
+    // const exitCode = await exec('docker', rest, execOptions)
+    const cmd = 'docker ' + (rest.join(' '));
+    const exitCode = await (0, exec_1.exec)(cmd, [], execOptions);
     return {
         exitCode,
         stderr,

--- a/dist/index.js
+++ b/dist/index.js
@@ -11073,6 +11073,9 @@ async function buildStage(stage, extraTags) {
         ]);
         const buildArgs = (0, helpers_1.getBuildArgs)()
             .flatMap(arg => ['--build-arg', arg]);
+        if (useBuildx) {
+            buildArgs.push('--build-arg', 'BUILDKIT_INLINE_CACHE=1');
+        }
         const result = await (0, helpers_1.runDockerCommand)('build', ...buildArgs, ...cacheFromArg, ...dockerfileArg, '--tag', targetTag, '--target', stage, core.getInput('context'));
         if (result.exitCode > 0) {
             throw new Error('Docker build failed');

--- a/dist/index.js
+++ b/dist/index.js
@@ -11066,7 +11066,7 @@ async function buildStage(stage, extraTags) {
         const cacheFromArg = getAllPossibleCacheTargets()
             .flatMap(target => ['--cache-from', target]);
         const buildArgs = (0, helpers_1.getBuildArgs)()
-            .flatMap(arg => ['--build-arg', arg]);
+            .map(arg => `--build-arg ${arg}`);
         const result = await (0, helpers_1.runDockerCommand)(buildCommand, 
         // '--build-arg', 'BUILDKIT_INLINE_CACHE="1"',
         ...buildArgs, ...cacheFromArg, ...dockerfileArg, '--tag', targetTag, '--target', stage, core.getInput('context'));

--- a/dist/index.js
+++ b/dist/index.js
@@ -11058,7 +11058,7 @@ async function build() {
 async function buildStage(stage, extraTags) {
     return (0, helpers_1.time)(`Build ${stage}`, async () => {
         core.startGroup(`Building stage: ${stage}`);
-        const buildCommand = (0, helpers_1.shouldBuildInParallel)() ? 'buildx' : 'build';
+        const buildCommand = (0, helpers_1.shouldBuildInParallel)() ? 'buildx build' : 'build';
         const dockerfile = core.getInput('dockerfile');
         const dockerfileArg = (dockerfile === '') ? [] : ['--file', dockerfile];
         const targetTag = (0, helpers_1.getTaggedImageForStage)(stage, (0, helpers_1.getTagForRun)());

--- a/dist/index.js
+++ b/dist/index.js
@@ -11068,7 +11068,7 @@ async function buildStage(stage, extraTags) {
         const cacheFromArg = getAllPossibleCacheTargets()
             .flatMap(target => ['--cache-from', target]);
         const buildArgs = (0, helpers_1.getBuildArgs)()
-            .map(arg => `--build-arg ${arg}`);
+            .flatMap(arg => ['--build-arg', arg]);
         const result = await (0, helpers_1.runDockerCommand)(buildCommand, 
         // '--build-arg', 'BUILDKIT_INLINE_CACHE="1"',
         ...buildArgs, ...cacheFromArg, ...dockerfileArg, '--tag', targetTag, '--target', stage, core.getInput('context'));

--- a/dist/index.js
+++ b/dist/index.js
@@ -10894,13 +10894,13 @@ exports.getTaggedImageForStage = getTaggedImageForStage;
 async function runDockerCommand(command, ...args) {
     const rest = [command];
     if (command === 'build' && shouldBuildInParallel()) {
-        rest.unshift('buildx');
+        rest.push('buildx');
     }
-    core.info(JSON.stringify(args));
     if (core.getBooleanInput('quiet') && command !== 'tag') {
         rest.push('--quiet');
     }
     rest.push(...args);
+    core.info(JSON.stringify(rest));
     let stdout = '';
     let stderr = '';
     const execOptions = {

--- a/dist/index.js
+++ b/dist/index.js
@@ -10810,14 +10810,22 @@ const github = __importStar(__nccwpck_require__(5438));
 // Returns a string like "refs_pull_1_merge-bk1"
 function getTagForRun() {
     var _a;
-    const usingBuildkit = process.env.DOCKER_BUILDKIT === '1';
+    const parallel = shouldBuildInParallel();
     const tagFriendlyRef = (_a = process.env.GITHUB_REF) === null || _a === void 0 ? void 0 : _a.replace(/\//g, '_');
-    return `${tagFriendlyRef}-bk${usingBuildkit ? '1' : '0'}`;
+    return `${tagFriendlyRef}-bk${parallel ? '1' : '0'}`;
 }
 exports.getTagForRun = getTagForRun;
 function shouldBuildInParallel() {
-    // This may become more directly configurable
-    return process.env.DOCKER_BUILDKIT === '1';
+    // Respect DOCKER_BUILDKIT, if set.
+    if (process.env.DOCKER_BUILDKIT === '1') {
+        core.debug('Building in parallel due to DOCKER_BUILDKIT=1');
+        return true;
+    }
+    else if (process.env.DOCKER_BUILDKIT === '0') {
+        core.debug('Not building in parallel due to DOCKER_BUILDKIT=0');
+        return false;
+    }
+    return core.getBooleanInput('parallel');
 }
 exports.shouldBuildInParallel = shouldBuildInParallel;
 function isDefaultBranch() {

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13 AS env
+FROM alpine:3.13@sha256:469b6e04ee185740477efa44ed5bdd64a07bbdd6c7e5f5d169e540889597b911 AS env
 WORKDIR app
 RUN apk add --update --no-cache icu-dev
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -4,14 +4,14 @@ import * as github from '@actions/github'
 
 // Returns a string like "refs_pull_1_merge-bk1"
 export function getTagForRun(): string {
-  const usingBuildkit = process.env.DOCKER_BUILDKIT === '1'
+  const parallel = shouldBuildInParallel()
   const tagFriendlyRef = process.env.GITHUB_REF?.replace(/\//g, '_') as unknown as string
 
-  return `${tagFriendlyRef}-bk${usingBuildkit ? '1' : '0'}`
+  return `${tagFriendlyRef}-bk${parallel ? '1' : '0'}`
 }
 
 export function shouldBuildInParallel(): boolean {
-  // Respect
+  // Respect DOCKER_BUILDKIT, if set.
   if (process.env.DOCKER_BUILDKIT === '1') {
     core.debug('Building in parallel due to DOCKER_BUILDKIT=1')
     return true

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -100,7 +100,7 @@ interface ExecResult {
 export async function runDockerCommand(command: DockerCommand, ...args: string[]): Promise<ExecResult> {
   const rest: string[] = [command]
   if (command === 'build' && shouldBuildInParallel()) {
-    rest.push('buildx')
+    rest.unshift('buildx')
   }
   if (core.getBooleanInput('quiet') && command !== 'tag') {
     rest.push('--quiet')

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -100,13 +100,13 @@ interface ExecResult {
 export async function runDockerCommand(command: DockerCommand, ...args: string[]): Promise<ExecResult> {
   const rest: string[] = [command]
   if (command === 'build' && shouldBuildInParallel()) {
-    rest.unshift('buildx')
+    rest.push('buildx')
   }
-  core.info(JSON.stringify(args))
   if (core.getBooleanInput('quiet') && command !== 'tag') {
     rest.push('--quiet')
   }
   rest.push(...args)
+  core.info(JSON.stringify(rest))
 
   let stdout = ''
   let stderr = ''

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -10,6 +10,11 @@ export function getTagForRun(): string {
   return `${tagFriendlyRef}-bk${usingBuildkit ? '1' : '0'}`
 }
 
+export function shouldBuildInParallel(): boolean {
+  // This may become more directly configurable
+  return process.env.DOCKER_BUILDKIT === '1'
+}
+
 export function isDefaultBranch(): boolean {
   const defaultBranch = github.context.payload.repository?.default_branch as string
   return github.context.payload.ref === `refs/heads/${defaultBranch}`
@@ -80,7 +85,7 @@ export function getTaggedImageForStage(stage: string, tag: string): string {
   return `${image}:${tag}`
 }
 
-type DockerCommand = 'pull' | 'push' | 'build' | 'tag'
+type DockerCommand = 'pull' | 'push' | 'build' | 'tag' | 'buildx'
 
 interface ExecResult {
   exitCode: number

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -99,6 +99,7 @@ interface ExecResult {
  */
 export async function runDockerCommand(command: DockerCommand, ...args: string[]): Promise<ExecResult> {
   const rest: string[] = [command]
+  core.info(JSON.stringify(args))
   if (core.getBooleanInput('quiet') && command !== 'tag') {
     rest.push('--quiet')
   }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -119,7 +119,10 @@ export async function runDockerCommand(command: DockerCommand, ...args: string[]
       },
     }
   }
-  const exitCode = await exec('docker', rest, execOptions)
+  // const exitCode = await exec('docker', rest, execOptions)
+
+  const cmd = 'docker ' + (rest.join(' '))
+  const exitCode = await exec(cmd, [], execOptions)
 
   return {
     exitCode,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -11,8 +11,15 @@ export function getTagForRun(): string {
 }
 
 export function shouldBuildInParallel(): boolean {
-  // This may become more directly configurable
-  return process.env.DOCKER_BUILDKIT === '1'
+  // Respect
+  if (process.env.DOCKER_BUILDKIT === '1') {
+    core.debug('Building in parallel due to DOCKER_BUILDKIT=1')
+    return true
+  } else if (process.env.DOCKER_BUILDKIT === '0') {
+    core.debug('Not building in parallel due to DOCKER_BUILDKIT=0')
+    return false
+  }
+  return core.getBooleanInput('parallel')
 }
 
 export function isDefaultBranch(): boolean {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -85,7 +85,7 @@ export function getTaggedImageForStage(stage: string, tag: string): string {
   return `${image}:${tag}`
 }
 
-type DockerCommand = 'pull' | 'push' | 'build' | 'tag' | 'buildx build'
+type DockerCommand = 'pull' | 'push' | 'build' | 'tag'
 
 interface ExecResult {
   exitCode: number

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -99,6 +99,9 @@ interface ExecResult {
  */
 export async function runDockerCommand(command: DockerCommand, ...args: string[]): Promise<ExecResult> {
   const rest: string[] = [command]
+  if (command === 'build' && shouldBuildInParallel()) {
+    rest.unshift('buildx')
+  }
   core.info(JSON.stringify(args))
   if (core.getBooleanInput('quiet') && command !== 'tag') {
     rest.push('--quiet')
@@ -119,10 +122,7 @@ export async function runDockerCommand(command: DockerCommand, ...args: string[]
       },
     }
   }
-  // const exitCode = await exec('docker', rest, execOptions)
-
-  const cmd = 'docker ' + (rest.join(' '))
-  const exitCode = await exec(cmd, [], execOptions)
+  const exitCode = await exec('docker', rest, execOptions)
 
   return {
     exitCode,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -85,7 +85,7 @@ export function getTaggedImageForStage(stage: string, tag: string): string {
   return `${image}:${tag}`
 }
 
-type DockerCommand = 'pull' | 'push' | 'build' | 'tag' | 'buildx'
+type DockerCommand = 'pull' | 'push' | 'build' | 'tag' | 'buildx build'
 
 interface ExecResult {
   exitCode: number

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {
   getAllStages,
   getTaggedImageForStage,
   runDockerCommand,
+  shouldBuildInParallel,
   time,
 } from './helpers'
 
@@ -97,6 +98,8 @@ async function buildStage(stage: string, extraTags: string[]): Promise<string> {
   return time(`Build ${stage}`, async () => {
     core.startGroup(`Building stage: ${stage}`)
 
+    const buildCommand = shouldBuildInParallel() ? 'buildx' : 'build'
+
     const dockerfile = core.getInput('dockerfile')
     const dockerfileArg = (dockerfile === '') ? [] : ['--file', dockerfile]
 
@@ -109,7 +112,7 @@ async function buildStage(stage: string, extraTags: string[]): Promise<string> {
       .flatMap(arg => ['--build-arg', arg])
 
     const result = await runDockerCommand(
-      'build',
+      buildCommand,
       // '--build-arg', 'BUILDKIT_INLINE_CACHE="1"',
       ...buildArgs,
       ...cacheFromArg,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {
   getAllStages,
   getTaggedImageForStage,
   runDockerCommand,
+  shouldBuildInParallel,
   time,
 } from './helpers'
 
@@ -107,6 +108,9 @@ async function buildStage(stage: string, extraTags: string[]): Promise<string> {
 
     const buildArgs = getBuildArgs()
       .flatMap(arg => ['--build-arg', arg])
+    if (shouldBuildInParallel()) {
+      buildArgs.push('--build-arg', 'BUILDKIT_INLINE_CACHE=1')
+    }
 
     const result = await runDockerCommand(
       'build',

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,7 @@ async function buildStage(stage: string, extraTags: string[]): Promise<string> {
   return time(`Build ${stage}`, async () => {
     core.startGroup(`Building stage: ${stage}`)
 
-    const buildCommand = shouldBuildInParallel() ? 'buildx' : 'build'
+    const buildCommand = shouldBuildInParallel() ? 'buildx build' : 'build'
 
     const dockerfile = core.getInput('dockerfile')
     const dockerfileArg = (dockerfile === '') ? [] : ['--file', dockerfile]

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,7 +113,10 @@ async function buildStage(stage: string, extraTags: string[]): Promise<string> {
 
     const buildArgs = getBuildArgs()
       .flatMap(arg => ['--build-arg', arg])
-    
+    if (useBuildx) {
+      buildArgs.push('--build-arg', 'BUILDKIT_INLINE_CACHE=1')
+    }
+
     const result = await runDockerCommand(
       'build',
       ...buildArgs,

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,7 @@ async function buildStage(stage: string, extraTags: string[]): Promise<string> {
       .flatMap(target => ['--cache-from', target])
 
     const buildArgs = getBuildArgs()
-      .flatMap(arg => ['--build-arg', arg])
+      .map(arg => `--build-arg ${arg}`)
 
     const result = await runDockerCommand(
       buildCommand,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,6 @@ import {
   getAllStages,
   getTaggedImageForStage,
   runDockerCommand,
-  shouldBuildInParallel,
   time,
 } from './helpers'
 
@@ -98,8 +97,6 @@ async function buildStage(stage: string, extraTags: string[]): Promise<string> {
   return time(`Build ${stage}`, async () => {
     core.startGroup(`Building stage: ${stage}`)
 
-    const buildCommand = shouldBuildInParallel() ? 'buildx build' : 'build'
-
     const dockerfile = core.getInput('dockerfile')
     const dockerfileArg = (dockerfile === '') ? [] : ['--file', dockerfile]
 
@@ -112,7 +109,7 @@ async function buildStage(stage: string, extraTags: string[]): Promise<string> {
       .flatMap(arg => ['--build-arg', arg])
 
     const result = await runDockerCommand(
-      buildCommand,
+      'build',
       // '--build-arg', 'BUILDKIT_INLINE_CACHE="1"',
       ...buildArgs,
       ...cacheFromArg,

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,24 +98,24 @@ async function buildStage(stage: string, extraTags: string[]): Promise<string> {
   return time(`Build ${stage}`, async () => {
     core.startGroup(`Building stage: ${stage}`)
 
+    const useBuildx = shouldBuildInParallel()
+
     const dockerfile = core.getInput('dockerfile')
     const dockerfileArg = (dockerfile === '') ? [] : ['--file', dockerfile]
 
     const targetTag = getTaggedImageForStage(stage, getTagForRun())
 
     const cacheFromArg = getAllPossibleCacheTargets()
-      .flatMap(target => ['--cache-from', `type=registry,ref=${target}`])
+      .flatMap(target => ['--cache-from', useBuildx
+        ? `type=registry,ref=${target}`
+        : target
+      ])
 
     const buildArgs = getBuildArgs()
       .flatMap(arg => ['--build-arg', arg])
-    shouldBuildInParallel()
-    // if (shouldBuildInParallel()) {
-    //   buildArgs.push('--build-arg', 'BUILDKIT_INLINE_CACHE=1')
-    // }
-
+    
     const result = await runDockerCommand(
       'build',
-      // '--build-arg', 'BUILDKIT_INLINE_CACHE="1"',
       ...buildArgs,
       ...cacheFromArg,
       ...dockerfileArg,

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,9 +108,10 @@ async function buildStage(stage: string, extraTags: string[]): Promise<string> {
 
     const buildArgs = getBuildArgs()
       .flatMap(arg => ['--build-arg', arg])
-    if (shouldBuildInParallel()) {
-      buildArgs.push('--build-arg', 'BUILDKIT_INLINE_CACHE=1')
-    }
+    shouldBuildInParallel()
+    // if (shouldBuildInParallel()) {
+    //   buildArgs.push('--build-arg', 'BUILDKIT_INLINE_CACHE=1')
+    // }
 
     const result = await runDockerCommand(
       'build',

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,7 @@ async function buildStage(stage: string, extraTags: string[]): Promise<string> {
       .flatMap(target => ['--cache-from', target])
 
     const buildArgs = getBuildArgs()
-      .map(arg => `--build-arg ${arg}`)
+      .flatMap(arg => ['--build-arg', arg])
 
     const result = await runDockerCommand(
       buildCommand,

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,7 @@ async function buildStage(stage: string, extraTags: string[]): Promise<string> {
     const targetTag = getTaggedImageForStage(stage, getTagForRun())
 
     const cacheFromArg = getAllPossibleCacheTargets()
-      .flatMap(target => ['--cache-from', target])
+      .flatMap(target => ['--cache-from', `type=registry,ref=${target}`])
 
     const buildArgs = getBuildArgs()
       .flatMap(arg => ['--build-arg', arg])


### PR DESCRIPTION
This adjusts the build process to use `buildx` (which may or may not be the best approach for parallel builds) AND adjusts some of the `--cache-from`/`--cache-to` flags so the pre-pulled caches should actually work (historically, enabling buildkit would miss cache and build from scratch most of the time)

https://docs.docker.com/build/cache/backends/

Fixes #36