### PR TITLE
Automate version tag management

### DIFF
--- a/.github/workflows/update-version-tags.yml
+++ b/.github/workflows/update-version-tags.yml
@@ -1,0 +1,22 @@
+name: Update version tags
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  update-tags:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Update major and minor version tags
+        run: ./scripts/update-version-tags.sh "${GITHUB_REF#refs/tags/}"

--- a/.github/workflows/update-version-tags.yml
+++ b/.github/workflows/update-version-tags.yml
@@ -4,6 +4,17 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to update (e.g., v1.2.3)'
+        required: true
+        type: string
+      dry-run:
+        description: 'Print commands without executing'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   update-tags:
@@ -18,5 +29,19 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Determine tag
+        id: tag
+        run: |
+          if [[ -n "${{ inputs.tag }}" ]]; then
+            echo "value=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Update major and minor version tags
-        run: ./scripts/update-version-tags.sh "${GITHUB_REF#refs/tags/}"
+        run: |
+          ARGS="${{ steps.tag.outputs.value }}"
+          if [[ "${{ inputs.dry-run }}" == "true" ]]; then
+            ARGS="$ARGS --dry-run"
+          fi
+          ./scripts/update-version-tags.sh $ARGS

--- a/scripts/update-version-tags.sh
+++ b/scripts/update-version-tags.sh
@@ -39,6 +39,6 @@ run() {
     fi
 }
 
-run git tag -fa "$MAJOR" -m "Update $MAJOR to $TAG"
-run git tag -fa "$MINOR" -m "Update $MINOR to $TAG"
-run git push -f origin "$MAJOR" "$MINOR"
+run git tag --force --annotate "$MAJOR" --message "Update $MAJOR to $TAG"
+run git tag --force --annotate "$MINOR" --message "Update $MINOR to $TAG"
+run git push --force origin "$MAJOR" "$MINOR"

--- a/scripts/update-version-tags.sh
+++ b/scripts/update-version-tags.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 <tag> [--dry-run]"
+    echo "  tag: semantic version tag (e.g., v1.2.3)"
+    echo "  --dry-run: print commands without executing"
+    exit 1
+}
+
+if [[ $# -lt 1 ]]; then
+    usage
+fi
+
+TAG=$1
+DRY_RUN=false
+
+if [[ $# -ge 2 && $2 == "--dry-run" ]]; then
+    DRY_RUN=true
+fi
+
+if [[ ! $TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: tag must match vX.Y.Z format"
+    exit 1
+fi
+
+MAJOR=$(echo "$TAG" | cut -d. -f1)
+MINOR=$(echo "$TAG" | cut -d. -f1-2)
+
+echo "Tag: $TAG"
+echo "Major: $MAJOR"
+echo "Minor: $MINOR"
+
+run() {
+    if $DRY_RUN; then
+        echo "[dry-run] $*"
+    else
+        "$@"
+    fi
+}
+
+run git tag -fa "$MAJOR" -m "Update $MAJOR to $TAG"
+run git tag -fa "$MINOR" -m "Update $MINOR to $TAG"
+run git push -f origin "$MAJOR" "$MINOR"


### PR DESCRIPTION
## Summary
- Add `scripts/update-version-tags.sh` with `--dry-run` support for local testing
- Add workflow triggered on `vX.Y.Z` tags that updates `vX.Y` and `vX` tags

When a semver tag like `v1.2.3` is pushed, the workflow automatically force-pushes `v1.2` and `v1` to match.

## Test plan
- [ ] `./scripts/update-version-tags.sh v1.2.3 --dry-run` works locally
- [ ] Push a test tag after merge to verify workflow runs